### PR TITLE
chores/refactoring options

### DIFF
--- a/Gemfile.travis.lock
+++ b/Gemfile.travis.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/zdennis/rawline.git
-  revision: 73c8961ac124853d8f80921582c3cc849f50b801
+  revision: 4f4a37d9d00ae760dcee18c091995941d10f7055
   specs:
     yap-rawline (0.7.0)
       ansi_string (~> 0.1)
@@ -62,10 +62,10 @@ GEM
     chronic (0.10.2)
     coderay (1.1.1)
     diff-lcs (1.2.5)
-    ffi (1.9.13)
+    ffi (1.9.14)
     highline (1.7.8)
     method_source (0.8.2)
-    pry (0.10.3)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)

--- a/bin/yap
+++ b/bin/yap
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+
+ENV['PWD'] = Dir.pwd
+
+# Start YAP with a pristine environment
+env2keep = {
+  # DISPLAY needs to be inherited in order to launch GUI apps
+  'DISPLAY' => ENV['DISPLAY'],
+  'HOME' => ENV['HOME'],
+  'PATH' => ENV['PATH'],
+  'PWD' => ENV['PWD'],
+
+  # For Yap's sanity
+  'RUBYOPT' => '-rubygems -EUTF-8',
+
+  # Inherit the user's preferred shell
+  'SHELL' => ENV['SHELL'],
+
+  # Set the logged in user
+  'USER' => ENV['USER'],
+
+  # Necessary for ssh-agent
+  'SSH_AUTH_SOCK' => ENV['SSH_AUTH_SOCK'],
+
+  # DEBUG/TREEFELL_OUT are for debuging yap itself
+  'DEBUG' => ENV['DEBUG'],
+  'TREEFELL_OUT' => ENV['TREEFELL_OUT']
+}
+
+ENV.clear
+env_params = env2keep.each_with_object([]) do |(key,value),arr|
+  # next if value.nil?
+  arr << %|#{key}="#{value}"|
+  ENV[key] = value
+end.join(' ')
+
+file = __FILE__
+if File.symlink?(file)
+  file = File.readlink(file)
+end
+
+trap "SIGTSTP", "IGNORE"
+trap "SIGINT", "IGNORE"
+trap "SIGTTIN", "IGNORE"
+trap "SIGTTOU", "IGNORE"
+
+ENV['TERM'] ||= 'linux'
+
+require "yap-shell-core"
+
+STDOUT.sync = true
+STDERR.sync = true
+
+Yap.run_shell(ARGV)

--- a/lib/yap-shell-core.rb
+++ b/lib/yap-shell-core.rb
@@ -19,8 +19,8 @@ module Yap
   def self.run_shell(argv)
     Treefell['shell'].puts "#{self}.#{__callee__} booting shell"
 
-    yap_options = Yap::Cli::Options.new
-    yap_options.parse(argv)
+    main_options = Yap::Cli::Options::Main.new
+    main_options.parse(argv)
 
     if configuration.run_shell?
       configuration.yap_binpath = File.expand_path($0)
@@ -43,8 +43,8 @@ module Yap
       end
 
       Shell::Impl.new(addons: addons_loaded).repl
-    elsif yap_options.commands.any?
-      yap_options.commands.last.process
+    elsif main_options.commands.any?
+      main_options.commands.last.process
     else
       STDERR.puts "Honestly, I don't know what you're tring to do."
       exit 1

--- a/lib/yap-shell-core.rb
+++ b/lib/yap-shell-core.rb
@@ -9,6 +9,7 @@ module Yap
   require 'yap/cli/options'
   require 'yap/configuration'
   require 'yap/shell'
+  require 'yap/support'
   require 'yap/world'
 
   def self.root

--- a/lib/yap/addon/path.rb
+++ b/lib/yap/addon/path.rb
@@ -29,8 +29,8 @@ module Yap
           Dir["#{path}/*"].map do |directory|
             next unless File.directory?(directory)
 
-            if File.basename(directory) =~ /(yap-shell-addon-(.*))-\d+\.\d+\.\d+/
-              require_as, name = $1, $2
+            if File.basename(directory) =~ /(yap-shell-addon-(.*))-(\d+\.\d+\.\d+)/
+              require_as, name, version = $1, $2, $3
 
               addonrb_path = directory + "/lib/" + require_as + ".rb"
               export_as = ExportAs.find_in_file(addonrb_path)
@@ -45,7 +45,8 @@ module Yap
                 name: name,
                 require_as: require_as,
                 path: File.expand_path(directory),
-                enabled: enabled
+                enabled: enabled,
+                version: version
               )
             end
           end

--- a/lib/yap/addon/reference.rb
+++ b/lib/yap/addon/reference.rb
@@ -1,13 +1,14 @@
 module Yap
   module Addon
     class Reference
-      attr_reader :name, :require_as, :path
+      attr_reader :name, :require_as, :path, :version
 
-      def initialize(name:, require_as:, path:, enabled: true)
+      def initialize(name:, require_as:, path:, version:, enabled: true)
         @name = name
         @require_as = require_as
         @path = path
         @enabled = enabled
+        @version = version
       end
 
       def disabled?

--- a/lib/yap/cli.rb
+++ b/lib/yap/cli.rb
@@ -1,4 +1,7 @@
+require 'term/ansicolor'
+
 module Yap
   module Cli
+    Colors = ::Term::ANSIColor
   end
 end

--- a/lib/yap/cli/commands.rb
+++ b/lib/yap/cli/commands.rb
@@ -1,6 +1,11 @@
+require 'yap/support/file_utils_helper'
+
 module Yap
   module Cli
     module Commands
+      class Base
+        include ::Yap::Support::FileUtilsHelper
+      end
     end
   end
 end

--- a/lib/yap/cli/commands/addon.rb
+++ b/lib/yap/cli/commands/addon.rb
@@ -1,7 +1,7 @@
 module Yap
   module Cli
     module Commands
-      class Addon
+      class Addon < Base
         def initialize(addon_name)
           @addon_name = addon_name
         end

--- a/lib/yap/cli/commands/addon/disable.rb
+++ b/lib/yap/cli/commands/addon/disable.rb
@@ -1,7 +1,7 @@
 module Yap
   module Cli
     module Commands
-      class Addon::Disable
+      class Addon::Disable < Base
         def initialize(addon_name)
           @addon_name = addon_name
         end
@@ -22,8 +22,8 @@ module Yap
 
           if found_addon_ref
             destination = configuration.yap_addons_configuration_path.to_s
-            FileUtils.mkdir_p File.dirname(destination)
-            File.write destination, addon_config_hsh.to_yaml
+            file_utils.mkdir_p file_utils.dirname(destination)
+            file_utils.write destination, addon_config_hsh.to_yaml
             puts "Addon #{found_addon_ref.name} has been disabled"
           else
             puts "Could not find addon with name #{@addon_name}"

--- a/lib/yap/cli/commands/addon/enable.rb
+++ b/lib/yap/cli/commands/addon/enable.rb
@@ -1,7 +1,7 @@
 module Yap
   module Cli
     module Commands
-      class Addon::Enable
+      class Addon::Enable < Base
         def initialize(addon_name)
           @addon_name = addon_name
         end
@@ -22,8 +22,8 @@ module Yap
 
           if found_addon_ref
             destination = configuration.yap_addons_configuration_path.to_s
-            FileUtils.mkdir_p File.dirname(destination)
-            File.write destination, addon_config_hsh.to_yaml
+            file_utils.mkdir_p file_utils.dirname(destination)
+            file_utils.write destination, addon_config_hsh.to_yaml
             puts "Addon #{found_addon_ref.name} has been enabled"
           else
             puts "Could not find addon with name #{@addon_name}"

--- a/lib/yap/cli/commands/addon/install.rb
+++ b/lib/yap/cli/commands/addon/install.rb
@@ -1,0 +1,26 @@
+require 'term/ansicolor'
+
+module Yap
+  module Cli
+    module Commands
+      class Addon::Install < Base
+        include Term::ANSIColor
+
+        def initialize(addon_name)
+          @addon_name = addon_name
+        end
+
+        def process
+          output = `gem install yap-shell-addon-#{@addon_name}`
+          if $?.exitstatus == 0
+            puts Colors.green("#{@addon_name} was installed successfully.")
+            puts "Don't forget to run #{Colors.yellow('reload!')} to load the addon."
+          else
+            puts Colors.red("#{@addon_name} failed to install:")
+            puts output
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yap/cli/commands/addon/list.rb
+++ b/lib/yap/cli/commands/addon/list.rb
@@ -12,7 +12,7 @@ module Yap
           addon_refs = ::Yap::Addon::Path.
             find_for_configuration(configuration)
           if addon_refs.empty?
-            puts <<-MSG.strip_heredoc
+            puts <<-MSG.gsub(/^\s*\|/, '')
               |No addons found searching paths:
               |  - #{configuration.addon_paths.join("\n  -")}
             MSG

--- a/lib/yap/cli/commands/addon/list.rb
+++ b/lib/yap/cli/commands/addon/list.rb
@@ -1,9 +1,21 @@
+require 'yap/cli/console/printer'
+
 module Yap
   module Cli
     module Commands
       class Addon::List < Base
         def filter=(filter_kind)
           @filter = filter_kind
+        end
+
+        def print_list(addon_refs, with_state: true)
+          data = addon_refs.group_by(&:name).map do |name, refs|
+            sorted_refs = refs.sort_by(&:version)
+            most_recent_ref = sorted_refs.last
+            enabled_or_disabled = most_recent_ref.enabled? ? Colors.green('enabled') : Colors.intense_black('disabled')
+            [most_recent_ref.name.to_s, enabled_or_disabled, "(#{refs.reverse.map(&:version).join(', ')})"]
+          end
+          Console::Printer.new(data).print_table
         end
 
         def process
@@ -17,18 +29,11 @@ module Yap
               |  - #{configuration.addon_paths.join("\n  -")}
             MSG
           elsif @filter == :enabled
-            addon_refs.select(&:enabled?).each do |addon_ref|
-              puts "#{addon_ref.name}"
-            end
+            print_list addon_refs.select(&:enabled?)
           elsif @filter == :disabled
-            addon_refs.select(&:disabled?).each do |addon_ref|
-              puts "#{addon_ref.name}"
-            end
+            print_list addon_refs.select(&:disabled?)
           else
-            addon_refs.each do |addon_ref|
-              enabled_or_disabled = addon_ref.enabled? ? 'enabled' : 'disabled'
-              puts "#{addon_ref.name} (#{enabled_or_disabled})"
-            end
+            print_list addon_refs
           end
         end
       end

--- a/lib/yap/cli/commands/addon/list.rb
+++ b/lib/yap/cli/commands/addon/list.rb
@@ -1,7 +1,7 @@
 module Yap
   module Cli
     module Commands
-      class Addon::List
+      class Addon::List < Base
         def filter=(filter_kind)
           @filter = filter_kind
         end

--- a/lib/yap/cli/commands/addon/search.rb
+++ b/lib/yap/cli/commands/addon/search.rb
@@ -85,10 +85,10 @@ module Yap
           output = output.join("\n")
 
           highlighted_output = output.gsub(/(#{Regexp.escape(search_term)})/) do
-            Term::ANSIColor.cyan($1)
+            Colors.cyan($1)
           end
 
-          puts Term::ANSIColor.bright_black(
+          puts Colors.bright_black(
             sprintf("#{format_string}", *longest.keys.map { |key| headers[key] })
           )
           puts highlighted_output

--- a/lib/yap/cli/commands/addon/search.rb
+++ b/lib/yap/cli/commands/addon/search.rb
@@ -1,7 +1,7 @@
 module Yap
   module Cli
     module Commands
-      class Addon::Search
+      class Addon::Search < Base
         attr_accessor :all, :local, :prerelease, :search_term, :version
         attr_accessor :show_gem_name
 

--- a/lib/yap/cli/commands/addon/uninstall.rb
+++ b/lib/yap/cli/commands/addon/uninstall.rb
@@ -1,0 +1,24 @@
+require 'term/ansicolor'
+
+module Yap
+  module Cli
+    module Commands
+      class Addon::Uninstall < Base
+        def initialize(addon_name)
+          @addon_name = addon_name
+        end
+
+        def process
+          output = `gem uninstall -a yap-shell-addon-#{@addon_name}`
+          if $?.exitstatus == 0
+            puts Colors.green("#{@addon_name} was uninstalled succesfully.")
+            puts "Don't forget to run #{Colors.yellow('reload!')} to start a session with the addon."
+          else
+            puts Colors.red("#{@addon_name} failed to uninstall:")
+            puts output
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yap/cli/commands/generate.rb
+++ b/lib/yap/cli/commands/generate.rb
@@ -4,7 +4,7 @@ require 'term/ansicolor'
 module Yap
   module Cli
     module Commands
-      class Generate
+      class Generate < Base
         def process
         end
       end

--- a/lib/yap/cli/commands/generate/addon.rb
+++ b/lib/yap/cli/commands/generate/addon.rb
@@ -4,7 +4,7 @@ require 'term/ansicolor'
 module Yap
   module Cli
     module Commands
-      class Generate::Addon
+      class Generate::Addon < Base
         attr_accessor :addon_name, :version, :use_git
 
         def initialize(addon_name)
@@ -67,12 +67,12 @@ module Yap
         private
 
         def mkdir(path)
-          doing("Create directory: #{path}"){ FileUtils.mkdir_p path }
+          doing("Create directory: #{path}"){ file_utils.mkdir_p path }
         end
 
         def write_file(path, contents)
           doing "Creating file: #{path}" do
-            File.write path, contents
+            file_utils.write path, contents
           end
         end
 
@@ -81,11 +81,11 @@ module Yap
         end
 
         def addonrb_path
-          File.join(lib_path, gem_safe_addon_name + '.rb')
+          file_utils.join(lib_path, gem_safe_addon_name + '.rb')
         end
 
         def addonrb_contents
-          contents = File.read(File.dirname(__FILE__) + '/addonrb.template')
+          contents = file_utils.read(file_utils.dirname(__FILE__) + '/addonrb.template')
           contents % addonrb_template_variables
         end
 
@@ -127,7 +127,7 @@ module Yap
         end
 
         def gemspec_contents
-          contents = File.read(File.dirname(__FILE__) + '/gemspec.template')
+          contents = file_utils.read(file_utils.dirname(__FILE__) + '/gemspec.template')
           contents % gemspec_template_variables
         end
 
@@ -177,15 +177,15 @@ module Yap
         end
 
         def lib_path
-          File.join('lib')
+          file_utils.join('lib')
         end
 
         def lib_addon_path
-          File.join(lib_path, addon_dir)
+          file_utils.join(lib_path, addon_dir)
         end
 
         def license_contents
-          contents = File.read(File.dirname(__FILE__) + '/license.template')
+          contents = file_utils.read(file_utils.dirname(__FILE__) + '/license.template')
           contents % license_template_variables
         end
 
@@ -206,11 +206,11 @@ module Yap
         end
 
         def rakefile_contents
-          File.read(File.dirname(__FILE__) + '/rakefile.template')
+          file_utils.read(file_utils.dirname(__FILE__) + '/rakefile.template')
         end
 
         def readme_contents
-          contents = File.read(File.dirname(__FILE__) + '/readme.template')
+          contents = file_utils.read(file_utils.dirname(__FILE__) + '/readme.template')
           contents % readme_template_variables
         end
 
@@ -237,7 +237,7 @@ module Yap
         end
 
         def version_path
-          File.join(lib_addon_path, 'version.rb')
+          file_utils.join(lib_addon_path, 'version.rb')
         end
 
         def version_contents

--- a/lib/yap/cli/commands/generate/addon.rb
+++ b/lib/yap/cli/commands/generate/addon.rb
@@ -16,11 +16,11 @@ module Yap
         def doing(text, &block)
           print "#{text}"
           block.call
-          puts " #{Term::ANSIColor.green('done')}"
+          puts " #{Colors.green('done')}"
         end
 
         def process
-          puts "Creating addon #{Term::ANSIColor.yellow(addon_name)} in #{addon_dir}/"
+          puts "Creating addon #{Colors.yellow(addon_name)} in #{addon_dir}/"
           puts
 
           mkdir addon_dir
@@ -42,7 +42,7 @@ module Yap
                 `git init . && git add . && git commit -m 'initial commit of #{addon_name} addon for yap'`
               end
             else
-              puts "Git initialization #{Term::ANSIColor.cyan('skipped')}"
+              puts "Git initialization #{Colors.cyan('skipped')}"
             end
           end
 
@@ -50,9 +50,9 @@ module Yap
           puts "Yap addon generated! A few helpful things to note:"
           puts
           puts <<-TEXT.gsub(/^\s*\|/, '')
-            |  * The #{Term::ANSIColor.yellow(addon_name)} addon has been generated in #{addon_dir}/
-            |  * It is a standard rubygem, has its own gemspec, and is named #{Term::ANSIColor.yellow(gem_safe_addon_name)}
-            |  * Yap loads the #{Term::ANSIColor.yellow(constant_name)}, found in #{addonrb_path} (start there)
+            |  * The #{Colors.yellow(addon_name)} addon has been generated in #{addon_dir}/
+            |  * It is a standard rubygem, has its own gemspec, and is named #{Colors.yellow(gem_safe_addon_name)}
+            |  * Yap loads the #{Colors.yellow(constant_name)}, found in #{addonrb_path} (start there)
             |  * Share your addon with others by building a gem and pushing it to rubygems
             |
             |For more information see https://github.com/zdennis/yap-shell/wiki/Addons

--- a/lib/yap/cli/console.rb
+++ b/lib/yap/cli/console.rb
@@ -1,0 +1,6 @@
+module Yap
+  module Cli
+    module Console
+    end
+  end
+end

--- a/lib/yap/cli/console/printer.rb
+++ b/lib/yap/cli/console/printer.rb
@@ -1,0 +1,26 @@
+module Yap
+  module Cli
+    module Console
+      class Printer
+        def initialize(data)
+          @data = data
+        end
+
+        def print_table
+          return if @data.empty?
+          number_of_columns = @data.first.length
+          column_widths = Hash.new { |h,k| h[k] = 0 }
+          number_of_columns.times do |i|
+            column_widths[i] = @data.map { |row| row[i].length }.max
+          end
+          @data.each do |row|
+            row.each_with_index do |cell, i|
+              printf("%-#{column_widths[i]}s  ", cell)
+            end
+            puts
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yap/cli/options.rb
+++ b/lib/yap/cli/options.rb
@@ -6,8 +6,10 @@ module Yap
       class Base
         attr_reader :options
 
-        def initialize(options:)
+        def initialize(options:, stdout: $stdout, stderr: $stderr)
           @options = options
+          @stdout = stdout
+          @stderr = stderr
         end
 
         def load_command(path)
@@ -18,10 +20,16 @@ module Yap
           ::Yap::Support::FileLoader.load_constant_from_path(path)
         end
 
-        def load_relative_constant(path_str)
+        def load_relative_constant(path)
           base_path = self.class.name.downcase.gsub(/::/, '/')
           require_path = Pathname.new(base_path)
-          load_constant_from_path require_path.join(path_str).to_s
+          load_constant_from_path require_path.join(path).to_s
+        end
+
+        protected
+
+        def puts(*args)
+          stdout.puts *args
         end
       end
     end

--- a/lib/yap/cli/options.rb
+++ b/lib/yap/cli/options.rb
@@ -1,10 +1,8 @@
 require 'pathname'
-require 'yap/cli/options'
 
 module Yap
   module Cli
-    module OptionsLoader
-
+    class OptionsBase
       def load_command(path)
         load_constant_from_path Pathname.new('yap/cli/commands').join(path)
       end
@@ -20,9 +18,7 @@ module Yap
       end
     end
 
-    class Options
-      include OptionsLoader
-
+    class Options < OptionsBase
       attr_reader :options
 
       def initialize(options: {})
@@ -57,7 +53,6 @@ module Yap
 
           option_str = args.shift
           current_scope = scope + [option_str]
-
 
           begin
             options_class = load_relative_constant current_scope.join('/')

--- a/lib/yap/cli/options.rb
+++ b/lib/yap/cli/options.rb
@@ -1,9 +1,12 @@
 require 'pathname'
+require 'yap/support/file_utils_helper'
 
 module Yap
   module Cli
     module Options
       class Base
+        include ::Yap::Support::FileUtilsHelper
+
         attr_reader :options
 
         def initialize(options:, stdout: $stdout, stderr: $stderr)
@@ -17,7 +20,7 @@ module Yap
         end
 
         def load_constant_from_path(path)
-          ::Yap::Support::FileLoader.load_constant_from_path(path)
+          file_loader.load_constant_from_path(path)
         end
 
         def load_relative_constant(path)

--- a/lib/yap/cli/options.rb
+++ b/lib/yap/cli/options.rb
@@ -20,6 +20,7 @@ module Yap
           if requiring_path
             require requiring_path
             path_part = File.basename(requiring_path).sub(/\.rb$/, '')
+            path_part = "yap" if path_part == "yap-shell-core"
             requiring_parts.pop
             requiring_parts.push path_part
             constant_name = path_part.capitalize

--- a/lib/yap/cli/options.rb
+++ b/lib/yap/cli/options.rb
@@ -2,133 +2,30 @@ require 'pathname'
 
 module Yap
   module Cli
-    class OptionsBase
-      def load_command(path)
-        load_constant_from_path Pathname.new('yap/cli/commands').join(path)
-      end
+    module Options
+      class Base
+        attr_reader :options
 
-      def load_constant_from_path(path)
-        ::Yap::Support::FileLoader.load_constant_from_path(path)
-      end
-
-      def load_relative_constant(path_str)
-        base_path = self.class.name.downcase.gsub(/::/, '/')
-        require_path = Pathname.new(base_path)
-        load_constant_from_path require_path.join(path_str).to_s
-      end
-    end
-
-    class Options < OptionsBase
-      attr_reader :options
-
-      def initialize(options: {})
-        @options = options
-        @commands = []
-      end
-
-      def [](key)
-        @options[key]
-      end
-
-      def commands
-        @commands.dup.freeze
-      end
-
-      def parse(args)
-        option_parser.order!(args)
-        options_instance = self
-
-        Yap.configuration.run_shell = false if args.any?
-
-        scope = []
-        require_path = Pathname.new("yap/cli/options")
-        args_processed = []
-
-        while args.any?
-          if args_processed == args
-            puts "Unknown option(s*): #{scope.concat([args.first]).join(' ')}"
-            exit 1
-          end
-          args_processed = args.dup
-
-          option_str = args.shift
-          current_scope = scope + [option_str]
-
-          begin
-            options_class = load_relative_constant current_scope.join('/')
-            options_instance = options_class.new(options: options)
-            options[:option] = options_instance
-            options_instance.parse(args)
-            @commands << options_instance.command
-
-            scope << option_str
-          rescue LoadError => ex
-            puts "Unknown option: #{option_str}"
-            puts
-            puts options_instance.help_message
-            exit 1
-          end
+        def initialize(options:)
+          @options = options
         end
-      end
 
-      def help_message
-        option_parse.to_s
-      end
+        def load_command(path)
+          load_constant_from_path Pathname.new('yap/cli/commands').join(path)
+        end
 
-      private
+        def load_constant_from_path(path)
+          ::Yap::Support::FileLoader.load_constant_from_path(path)
+        end
 
-      def option_parser
-        OptionParser.new do |opts|
-          opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
-            |Usage: #{opts.program_name} [option|command]
-            |
-            |When a command is omitted the yap shell starts an interactive
-            |session. Otherwise, the command is executed.
-            |
-            |Shell options:
-          TEXT
-          opts.on('-h', '--help', 'Prints this help') do
-            puts opts
-            commands = Dir[ File.dirname(__FILE__) + '/commands/*.rb' ].map do |path|
-              command = File.basename(path).sub(/\.rb$/, '')
-              "#{command}: #{Term::ANSIColor.cyan(opts.program_name + ' ' + command + ' --help')}"
-            end
-            commands = %|  #{commands.join("\n  ")}|
-            puts <<-TEXT.gsub(/^\s*\|/, '')
-              |
-              |Commands:
-              |
-              |#{commands}
-              |
-            TEXT
-            exit 0
-          end
-
-          opts.on('--skip-first-time', 'Disables creating ~/.yap directory on shell startup') do
-            Yap.configuration.skip_first_time = true
-          end
-
-          opts.on('--addon-paths=PATHS', 'Paths to directories containing addons (comma-separated). This overwrites the default addon paths.') do |paths|
-            Yap.configuration.addon_paths = paths.split(',').map(&:strip)
-          end
-
-          opts.on('--no-addons', 'Disables auto-loading addons on shell startup') do
-            Yap.configuration.use_addons = false
-          end
-
-          opts.on('--no-history', 'Disables auto-loading or saving history') do
-            Yap.configuration.use_history = false
-          end
-
-          opts.on('--rcfiles=PATHS', 'Paths to Yap rcfiles in the order they should load (comma-separated). This overwrites the default rcfiles.') do |paths|
-            Yap.configuration.rcfiles = paths.split(',').map(&:strip)
-          end
-
-          opts.on('--no-rcfiles', 'Disables auto-loading rcfiles on shell startup') do
-            Yap.configuration.use_rcfiles = false
-          end
+        def load_relative_constant(path_str)
+          base_path = self.class.name.downcase.gsub(/::/, '/')
+          require_path = Pathname.new(base_path)
+          load_constant_from_path require_path.join(path_str).to_s
         end
       end
     end
   end
 end
+
+require 'yap/cli/options/main'

--- a/lib/yap/cli/options.rb
+++ b/lib/yap/cli/options.rb
@@ -31,6 +31,8 @@ module Yap
 
         protected
 
+        attr_reader :stdout, :stderr
+
         def puts(*args)
           stdout.puts *args
         end

--- a/lib/yap/cli/options.rb
+++ b/lib/yap/cli/options.rb
@@ -10,31 +10,7 @@ module Yap
       end
 
       def load_constant_from_path(path)
-        requiring_parts = []
-        path_parts = path.to_s.split('/')
-        requiring_path = nil
-        constant = path_parts.reduce(Object) do |constant, path_part|
-          requiring_parts << path_part
-          file2load = Yap.root.join('lib', requiring_parts.join('/') + "*.rb")
-          requiring_path = Dir[ file2load ].sort.first
-          if requiring_path
-            require requiring_path
-            path_part = File.basename(requiring_path).sub(/\.rb$/, '')
-            path_part = "yap" if path_part == "yap-shell-core"
-            requiring_parts.pop
-            requiring_parts.push path_part
-            constant_name = path_part.capitalize
-            if constant.const_defined?(constant_name)
-              constant = constant.const_get(constant_name)
-            else
-              fail "Couldn't find #{path_part} in #{constant}"
-            end
-          else
-            fail LoadError, "Couldn't load any file for #{file2load}"
-          end
-        end
-        Treefell['shell'].puts "#{inspect} loaded: #{constant}"
-        constant
+        ::Yap::Support::FileLoader.load_constant_from_path(path)
       end
 
       def load_relative_constant(path_str)

--- a/lib/yap/cli/options/addon.rb
+++ b/lib/yap/cli/options/addon.rb
@@ -1,59 +1,55 @@
 module Yap
   module Cli
-    class Options::Addon < OptionsBase
-      attr_reader :command, :options
+    module Options
+      class Addon < Base
+        def parse(args)
+          option_parser.order!(args)
+        end
 
-      def initialize(options:)
-        @options = options
-      end
+        def command
+          @command
+        end
 
-      def parse(args)
-        option_parser.order!(args)
-      end
+        def help_message
+          option_parser.to_s
+        end
 
-      def command
-        @command
-      end
+        private
 
-      def help_message
-        option_parser.to_s
-      end
+        def set_command(command)
+          @command = load_command('addon').new
+        end
 
-      private
-
-      def set_command(command)
-        @command = load_command('addon').new
-      end
-
-      def option_parser
-        OptionParser.new do |opts|
-          opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
-            |Usage: #{opts.program_name} addon [command] [addon-name] [options]
-            |
-            |#{Term::ANSIColor.cyan('yap addon')} can be used to control yap addons
-            |
-            |Generate commands:
-            |
-            |  #{Term::ANSIColor.yellow('enable')} - enables a yap addon
-            |  #{Term::ANSIColor.yellow('disable')} - disables a yap addon
-            |
-            |Generate options:
-          TEXT
-
-          opts.on('-h', '--help', 'Prints this help') do
-            puts opts
-            puts
-            puts  <<-TEXT.gsub(/^\s*\|/, '')
-              |Example: disabling an addon
+        def option_parser
+          OptionParser.new do |opts|
+            opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
+              |Usage: #{opts.program_name} addon [command] [addon-name] [options]
               |
-              |   #{opts.program_name} addon disable foo-bar
+              |#{Term::ANSIColor.cyan('yap addon')} can be used to control yap addons
               |
-              |Example: enabling an addon
+              |Generate commands:
               |
-              |   #{opts.program_name} addon enable foo-bar
+              |  #{Term::ANSIColor.yellow('enable')} - enables a yap addon
+              |  #{Term::ANSIColor.yellow('disable')} - disables a yap addon
               |
+              |Generate options:
             TEXT
-            exit 0
+
+            opts.on('-h', '--help', 'Prints this help') do
+              puts opts
+              puts
+              puts  <<-TEXT.gsub(/^\s*\|/, '')
+                |Example: disabling an addon
+                |
+                |   #{opts.program_name} addon disable foo-bar
+                |
+                |Example: enabling an addon
+                |
+                |   #{opts.program_name} addon enable foo-bar
+                |
+              TEXT
+              exit 0
+            end
           end
         end
       end

--- a/lib/yap/cli/options/addon.rb
+++ b/lib/yap/cli/options/addon.rb
@@ -25,12 +25,12 @@ module Yap
             opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
               |Usage: #{opts.program_name} addon [command] [addon-name] [options]
               |
-              |#{Term::ANSIColor.cyan('yap addon')} can be used to control yap addons
+              |#{Colors.cyan('yap addon')} can be used to control yap addons
               |
               |Generate commands:
               |
-              |  #{Term::ANSIColor.yellow('enable')} - enables a yap addon
-              |  #{Term::ANSIColor.yellow('disable')} - disables a yap addon
+              |  #{Colors.yellow('enable')} - enables a yap addon
+              |  #{Colors.yellow('disable')} - disables a yap addon
               |
               |Generate options:
             TEXT

--- a/lib/yap/cli/options/addon.rb
+++ b/lib/yap/cli/options/addon.rb
@@ -1,8 +1,6 @@
 module Yap
   module Cli
-    class Options::Addon
-      include OptionsLoader
-
+    class Options::Addon < OptionsBase
       attr_reader :command, :options
 
       def initialize(options:)

--- a/lib/yap/cli/options/addon/disable.rb
+++ b/lib/yap/cli/options/addon/disable.rb
@@ -1,57 +1,57 @@
 module Yap
   module Cli
-    class Options::Addon::Disable < OptionsBase
-      attr_reader :command, :options
-
-      def initialize(options:)
-        @options = options
-      end
-
-      def parse(args)
-        @addon_name = args.shift unless args.first =~ /^-/
-        unless @addon_name
-          args.unshift '--help'
-          STDERR.puts "Missing addon-name!"
-          @exit_status = 1
-          puts
-        end
-        option_parser.order!(args)
-      end
-
-      def command
-        @command ||= load_command('addon/disable').new(@addon_name)
-      end
-
-      def help_message
-        option_parser.to_s
-      end
-
-      private
-
-      def option_parser
-        OptionParser.new do |opts|
-          opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
-            |Usage: #{opts.program_name} addon disable [addon-name] [options]
-            |
-            |#{Term::ANSIColor.cyan('yap addon disable')} can be used to disable yap addons.
-            |
-            |Addon disable options:
-          TEXT
-
-          opts.on('-h', '--help', 'Prints this help') do
-            puts opts
+    module Options
+      class Addon::Disable < Base
+        def parse(args)
+          @addon_name = args.shift unless args.first =~ /^-/
+          unless @addon_name
+            args.unshift '--help'
+            STDERR.puts "Missing addon-name!"
+            @exit_status = 1
             puts
-            puts  <<-TEXT.gsub(/^\s*\|/, '')
-              |Example: Disable an addon
+          end
+          option_parser.order!(args)
+        end
+
+        def command
+          @command ||= load_command('addon/disable').new(@addon_name)
+        end
+
+        def exit_status
+          @exit_status || 0
+        end
+
+        def help_message
+          option_parser.to_s
+        end
+
+        private
+
+        def option_parser
+          OptionParser.new do |opts|
+            opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
+              |Usage: #{opts.program_name} addon disable [addon-name] [options]
               |
-              |   #{opts.program_name} addon disable magical-key-bindings
+              |#{Term::ANSIColor.cyan('yap addon disable')} can be used to disable yap addons.
               |
-              |Example: Enable an addon
-              |
-              |   #{opts.program_name} addon disable magical-key-bindings
-              |
+              |Addon disable options:
             TEXT
-            exit @exit_status
+
+            opts.on('-h', '--help', 'Prints this help') do
+              puts opts
+              puts
+              puts  <<-TEXT.gsub(/^\s*\|/, '')
+                |Example: Disable an addon
+                |
+                |   #{opts.program_name} addon disable magical-key-bindings
+                |
+                |Example: Enable an addon
+                |
+                |   #{opts.program_name} addon disable magical-key-bindings
+                |
+              TEXT
+              exit exit_status
+            end
           end
         end
       end

--- a/lib/yap/cli/options/addon/disable.rb
+++ b/lib/yap/cli/options/addon/disable.rb
@@ -6,7 +6,7 @@ module Yap
           @addon_name = args.shift unless args.first =~ /^-/
           unless @addon_name
             args.unshift '--help'
-            STDERR.puts "Missing addon-name!"
+            stderr.puts "Missing addon-name!"
             @exit_status = 1
             puts
           end

--- a/lib/yap/cli/options/addon/disable.rb
+++ b/lib/yap/cli/options/addon/disable.rb
@@ -1,8 +1,6 @@
 module Yap
   module Cli
-    class Options::Addon::Disable
-      include OptionsLoader
-
+    class Options::Addon::Disable < OptionsBase
       attr_reader :command, :options
 
       def initialize(options:)

--- a/lib/yap/cli/options/addon/disable.rb
+++ b/lib/yap/cli/options/addon/disable.rb
@@ -32,7 +32,7 @@ module Yap
             opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
               |Usage: #{opts.program_name} addon disable [addon-name] [options]
               |
-              |#{Term::ANSIColor.cyan('yap addon disable')} can be used to disable yap addons.
+              |#{Colors.cyan('yap addon disable')} can be used to disable yap addons.
               |
               |Addon disable options:
             TEXT

--- a/lib/yap/cli/options/addon/enable.rb
+++ b/lib/yap/cli/options/addon/enable.rb
@@ -32,7 +32,7 @@ module Yap
             opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
               |Usage: #{opts.program_name} addon enable [addon-name] [options]
               |
-              |#{Term::ANSIColor.cyan('yap addon enable')} can be used to enable yap addons.
+              |#{Colors.cyan('yap addon enable')} can be used to enable yap addons.
               |
               |Addon enable options:
             TEXT

--- a/lib/yap/cli/options/addon/enable.rb
+++ b/lib/yap/cli/options/addon/enable.rb
@@ -6,7 +6,7 @@ module Yap
           @addon_name = args.shift unless args.first =~ /^-/
           unless @addon_name
             args.unshift '--help'
-            STDERR.puts "Missing addon-name!"
+            stderr.puts "Missing addon-name!"
             @exit_status = 1
             puts
           end

--- a/lib/yap/cli/options/addon/enable.rb
+++ b/lib/yap/cli/options/addon/enable.rb
@@ -1,8 +1,6 @@
 module Yap
   module Cli
-    class Options::Addon::Enable
-      include OptionsLoader
-
+    class Options::Addon::Enable < OptionsBase
       attr_reader :command, :options
 
       def initialize(options:)

--- a/lib/yap/cli/options/addon/enable.rb
+++ b/lib/yap/cli/options/addon/enable.rb
@@ -1,58 +1,57 @@
 module Yap
   module Cli
-    class Options::Addon::Enable < OptionsBase
-      attr_reader :command, :options
-
-      def initialize(options:)
-        @options = options
-        @exit_status = 0
-      end
-
-      def parse(args)
-        @addon_name = args.shift unless args.first =~ /^-/
-        unless @addon_name
-          args.unshift '--help'
-          STDERR.puts "Missing addon-name!"
-          @exit_status = 1
-          puts
-        end
-        option_parser.order!(args)
-      end
-
-      def command
-        @command ||= load_command('addon/enable').new(@addon_name)
-      end
-
-      def help_message
-        option_parser.to_s
-      end
-
-      private
-
-      def option_parser
-        OptionParser.new do |opts|
-          opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
-            |Usage: #{opts.program_name} addon enable [addon-name] [options]
-            |
-            |#{Term::ANSIColor.cyan('yap addon enable')} can be used to enable yap addons.
-            |
-            |Addon enable options:
-          TEXT
-
-          opts.on('-h', '--help', 'Prints this help') do
-            puts opts
+    module Options
+      class Addon::Enable < Base
+        def parse(args)
+          @addon_name = args.shift unless args.first =~ /^-/
+          unless @addon_name
+            args.unshift '--help'
+            STDERR.puts "Missing addon-name!"
+            @exit_status = 1
             puts
-            puts  <<-TEXT.gsub(/^\s*\|/, '')
-              |Example: Disable an addon
+          end
+          option_parser.order!(args)
+        end
+
+        def command
+          @command ||= load_command('addon/enable').new(@addon_name)
+        end
+
+        def exit_status
+          @exit_status || 0
+        end
+
+        def help_message
+          option_parser.to_s
+        end
+
+        private
+
+        def option_parser
+          OptionParser.new do |opts|
+            opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
+              |Usage: #{opts.program_name} addon enable [addon-name] [options]
               |
-              |   #{opts.program_name} addon disable magical-key-bindings
+              |#{Term::ANSIColor.cyan('yap addon enable')} can be used to enable yap addons.
               |
-              |Example: Enable an addon
-              |
-              |   #{opts.program_name} addon enable magical-key-bindings
-              |
+              |Addon enable options:
             TEXT
-            exit @exit_status
+
+            opts.on('-h', '--help', 'Prints this help') do
+              puts opts
+              puts
+              puts  <<-TEXT.gsub(/^\s*\|/, '')
+                |Example: Disable an addon
+                |
+                |   #{opts.program_name} addon disable magical-key-bindings
+                |
+                |Example: Enable an addon
+                |
+                |   #{opts.program_name} addon enable magical-key-bindings
+                |
+              TEXT
+              exit exit_status
+            end
           end
         end
       end

--- a/lib/yap/cli/options/addon/install.rb
+++ b/lib/yap/cli/options/addon/install.rb
@@ -1,0 +1,52 @@
+module Yap
+  module Cli
+    module Options
+      class Addon::Install < Base
+        def parse(args)
+          @addon_name = args.shift unless args.first =~ /^-/
+          unless @addon_name
+            args.unshift '--help'
+            stderr.puts 'Missing addon-name!'
+            @exit_status = 1
+            puts
+          end
+          option_parser.order!(args)
+        end
+
+        def command
+          @command ||= load_command('addon/install').new(@addon_name)
+        end
+
+        def help_message
+          option_parser.to_s
+        end
+
+        private
+
+        def option_parser
+          OptionParser.new do |opts|
+            opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
+              |Usage: #{opts.program_name} addon install <addon-name> [options]
+              |
+              |#{Colors.cyan('yap addon install')} can be used to install addons.
+              |
+              |Install options:
+            TEXT
+
+            opts.on('-h', '--help', 'Prints this help') do
+              puts opts
+              puts
+              puts  <<-TEXT.gsub(/^\s*\|/, '')
+                |Example: Install an addon
+                |
+                |   #{opts.program_name} addon install super-cool-thing
+                |
+              TEXT
+              exit 0
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yap/cli/options/addon/list.rb
+++ b/lib/yap/cli/options/addon/list.rb
@@ -1,60 +1,60 @@
 module Yap
   module Cli
-    class Options::Addon::List < OptionsBase
-      attr_reader :command, :options
+    module Options
+      class Addon::List < Base
+        def initialize(options:)
+          @options = options
+        end
 
-      def initialize(options:)
-        @options = options
-      end
+        def parse(args)
+          option_parser.order!(args)
+        end
 
-      def parse(args)
-        option_parser.order!(args)
-      end
+        def command
+          @command ||= load_command('addon/list').new
+        end
 
-      def command
-        @command ||= load_command('addon/list').new
-      end
+        def help_message
+          option_parser.to_s
+        end
 
-      def help_message
-        option_parser.to_s
-      end
+        private
 
-      private
-
-      def option_parser
-        OptionParser.new do |opts|
-          opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
-            |Usage: #{opts.program_name} addon list [options]
-            |
-            |#{Term::ANSIColor.cyan('yap addon list')} can be used to list yap addons.
-            |
-            |Addon list options:
-          TEXT
-
-          opts.on('-h', '--help', 'Prints this help') do
-            puts opts
-            puts
-            puts  <<-TEXT.gsub(/^\s*\|/, '')
-              |Example: Listing all addons
+        def option_parser
+          OptionParser.new do |opts|
+            opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
+              |Usage: #{opts.program_name} addon list [options]
               |
-              |   #{opts.program_name} addon list
+              |#{Term::ANSIColor.cyan('yap addon list')} can be used to list yap addons.
               |
-              |Example: Listing disabled addons only
-              |
-              |   #{opts.program_name} addon list --disabled
-              |
-              |Example: Listing enabled addons only
-              |
-              |   #{opts.program_name} addon list --enabled
-              |
+              |Addon list options:
             TEXT
-            exit 0
-          end
-          opts.on('--enabled', 'Lists yap addons that are enabled') do
-            command.filter = :enabled
-          end
-          opts.on('--disabled', 'Lists yap addons that are disabled') do
-            command.filter = :disabled
+
+            opts.on('-h', '--help', 'Prints this help') do
+              puts opts
+              puts
+              puts  <<-TEXT.gsub(/^\s*\|/, '')
+                |Example: Listing all addons
+                |
+                |   #{opts.program_name} addon list
+                |
+                |Example: Listing disabled addons only
+                |
+                |   #{opts.program_name} addon list --disabled
+                |
+                |Example: Listing enabled addons only
+                |
+                |   #{opts.program_name} addon list --enabled
+                |
+              TEXT
+              exit 0
+            end
+            opts.on('--enabled', 'Lists yap addons that are enabled') do
+              command.filter = :enabled
+            end
+            opts.on('--disabled', 'Lists yap addons that are disabled') do
+              command.filter = :disabled
+            end
           end
         end
       end

--- a/lib/yap/cli/options/addon/list.rb
+++ b/lib/yap/cli/options/addon/list.rb
@@ -1,8 +1,6 @@
 module Yap
   module Cli
-    class Options::Addon::List
-      include OptionsLoader
-
+    class Options::Addon::List < OptionsBase
       attr_reader :command, :options
 
       def initialize(options:)

--- a/lib/yap/cli/options/addon/list.rb
+++ b/lib/yap/cli/options/addon/list.rb
@@ -2,10 +2,6 @@ module Yap
   module Cli
     module Options
       class Addon::List < Base
-        def initialize(options:)
-          @options = options
-        end
-
         def parse(args)
           option_parser.order!(args)
         end

--- a/lib/yap/cli/options/addon/list.rb
+++ b/lib/yap/cli/options/addon/list.rb
@@ -25,7 +25,7 @@ module Yap
             opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
               |Usage: #{opts.program_name} addon list [options]
               |
-              |#{Term::ANSIColor.cyan('yap addon list')} can be used to list yap addons.
+              |#{Colors.cyan('yap addon list')} can be used to list yap addons.
               |
               |Addon list options:
             TEXT

--- a/lib/yap/cli/options/addon/search.rb
+++ b/lib/yap/cli/options/addon/search.rb
@@ -1,8 +1,6 @@
 module Yap
   module Cli
-    class Options::Addon::Search
-      include OptionsLoader
-
+    class Options::Addon::Search < OptionsBase
       attr_reader :command, :options
 
       def initialize(options:)

--- a/lib/yap/cli/options/addon/search.rb
+++ b/lib/yap/cli/options/addon/search.rb
@@ -1,72 +1,67 @@
 module Yap
   module Cli
-    class Options::Addon::Search < OptionsBase
-      attr_reader :command, :options
-
-      def initialize(options:)
-        @options = options
-      end
-
-      def parse(args)
-        search_terms = []
-        while args.any?
-          option_parser.order!(args)
-          search_terms << args.shift
+    module Options
+      class Addon::Search < Base
+        def parse(args)
+          search_terms = []
+          while args.any?
+            option_parser.order!(args)
+            search_terms << args.shift
+          end
+          command.search_term = search_terms.shift
         end
-        command.search_term = search_terms.shift
-      end
 
-      def command
-        @command ||= load_command('addon/search').new
-      end
+        def command
+          @command ||= load_command('addon/search').new
+        end
 
-      def help_message
-        option_parser.to_s
-      end
+        def help_message
+          option_parser.to_s
+        end
 
-      private
+        private
 
-      def option_parser
-        OptionParser.new do |opts|
-          opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
-            |Usage: #{opts.program_name} addon search [options] [addon-name]
-            |
-            |#{Term::ANSIColor.cyan('yap addon search')} can be used to search for yap addons.
-            |
-            |Addon search options:
-          TEXT
-
-          opts.on('-h', '--help', 'Prints this help') do
-            puts opts
-            puts
-            puts  <<-TEXT.gsub(/^\s*\|/, '')
-              |Example: Search for an addon
+        def option_parser
+          OptionParser.new do |opts|
+            opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
+              |Usage: #{opts.program_name} addon search [options] [addon-name]
               |
-              |   #{opts.program_name} addon search --local foo
+              |#{Term::ANSIColor.cyan('yap addon search')} can be used to search for yap addons.
               |
-              |Example: Search for an addon locally (no network access)
-              |
-              |   #{opts.program_name} addon search foo
-              |
+              |Addon search options:
             TEXT
-            exit 0
-          end
-          opts.on('--local', 'Search locally, no network access') do
-            command.local = true
-          end
-          opts.on('-a', '--all', 'Display all addon versions') do
-            command.all = true
-          end
-          opts.on('--prerelease', 'Display prerelease versions') do
-            command.prerelease = true
-          end
-          opts.on('--gem-name', 'Display rubygem name instead of shortened yap addon name') do
-            command.show_gem_name = true
-          end
-          opts.on('-v', '--version VERSION', 'Specify version of addon to search') do |version|
-            command.version = version
-          end
 
+            opts.on('-h', '--help', 'Prints this help') do
+              puts opts
+              puts
+              puts  <<-TEXT.gsub(/^\s*\|/, '')
+                |Example: Search for an addon
+                |
+                |   #{opts.program_name} addon search --local foo
+                |
+                |Example: Search for an addon locally (no network access)
+                |
+                |   #{opts.program_name} addon search foo
+                |
+              TEXT
+              exit 0
+            end
+            opts.on('--local', 'Search locally, no network access') do
+              command.local = true
+            end
+            opts.on('-a', '--all', 'Display all addon versions') do
+              command.all = true
+            end
+            opts.on('--prerelease', 'Display prerelease versions') do
+              command.prerelease = true
+            end
+            opts.on('--gem-name', 'Display rubygem name instead of shortened yap addon name') do
+              command.show_gem_name = true
+            end
+            opts.on('-v', '--version VERSION', 'Specify version of addon to search') do |version|
+              command.version = version
+            end
+          end
         end
       end
     end

--- a/lib/yap/cli/options/addon/search.rb
+++ b/lib/yap/cli/options/addon/search.rb
@@ -26,7 +26,7 @@ module Yap
             opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
               |Usage: #{opts.program_name} addon search [options] [addon-name]
               |
-              |#{Term::ANSIColor.cyan('yap addon search')} can be used to search for yap addons.
+              |#{Colors.cyan('yap addon search')} can be used to search for yap addons.
               |
               |Addon search options:
             TEXT

--- a/lib/yap/cli/options/addon/uninstall.rb
+++ b/lib/yap/cli/options/addon/uninstall.rb
@@ -1,0 +1,52 @@
+module Yap
+  module Cli
+    module Options
+      class Addon::Uninstall < Base
+        def parse(args)
+          @addon_name = args.shift unless args.first =~ /^-/
+          unless @addon_name
+            args.unshift '--help'
+            stderr.puts 'Missing addon-name!'
+            @exit_status = 1
+            puts
+          end
+          option_parser.order!(args)
+        end
+
+        def command
+          @command ||= load_command('addon/uninstall').new(@addon_name)
+        end
+
+        def help_message
+          option_parser.to_s
+        end
+
+        private
+
+        def option_parser
+          OptionParser.new do |opts|
+            opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
+              |Usage: #{opts.program_name} addon uninstall <addon-name> [options]
+              |
+              |#{Colors.cyan('yap addon uninstall')} can be used to uninstall addons.
+              |
+              |Install options:
+            TEXT
+
+            opts.on('-h', '--help', 'Prints this help') do
+              puts opts
+              puts
+              puts  <<-TEXT.gsub(/^\s*\|/, '')
+                |Example: Uninstall an addon
+                |
+                |   #{opts.program_name} addon uninstall super-cool-thing
+                |
+              TEXT
+              exit 0
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yap/cli/options/generate.rb
+++ b/lib/yap/cli/options/generate.rb
@@ -5,7 +5,7 @@ module Yap
         def parse(args)
           if args.empty?
             args.unshift '--help'
-            STDERR.puts "generate must be called with a component type!"
+            stderr.puts "generate must be called with a component type!"
             @exit_status = 1
             puts
           end

--- a/lib/yap/cli/options/generate.rb
+++ b/lib/yap/cli/options/generate.rb
@@ -1,8 +1,6 @@
 module Yap
   module Cli
-    class Options::Generate
-      include OptionsLoader
-
+    class Options::Generate < OptionsBase
       attr_reader :command, :options
 
       def initialize(options:)

--- a/lib/yap/cli/options/generate.rb
+++ b/lib/yap/cli/options/generate.rb
@@ -1,54 +1,53 @@
 module Yap
   module Cli
-    class Options::Generate < OptionsBase
-      attr_reader :command, :options
+    module Options
+      class Generate < Base
+        def parse(args)
+          if args.empty?
+            args.unshift '--help'
+            STDERR.puts "generate must be called with a component type!"
+            @exit_status = 1
+            puts
+          end
 
-      def initialize(options:)
-        @options = options
-        @exit_status = 0
-      end
-
-      def parse(args)
-        if args.empty?
-          args.unshift '--help'
-          STDERR.puts "generate must be called with a component type!"
-          @exit_status = 1
-          puts
+          option_parser.order!(args)
         end
 
-        option_parser.order!(args)
-      end
+        def command
+          @command ||= load_command('generate').new
+        end
 
-      def command
-        @command ||= load_command('generate').new
-      end
+        def exit_status
+          @exit_status || 0
+        end
 
-      private
+        private
 
-      def option_parser
-        OptionParser.new do |opts|
-          opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
-            |Usage: #{opts.program_name} generate [component-type] [options]
-            |
-            |#{Term::ANSIColor.cyan('yap generate')} can be used to generate yap components, like an addon.
-            |
-            |Generate commands:
-            |
-            |  #{Term::ANSIColor.yellow('addon')} - generates a yap addon skeleton
-            |
-            |Generate options:
-          TEXT
-
-          opts.on('-h', '--help', 'Prints this help') do
-            puts opts
-            puts
-            puts  <<-TEXT.gsub(/^\s*\|/, '')
-              |Example: Generating an addon
+        def option_parser
+          OptionParser.new do |opts|
+            opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
+              |Usage: #{opts.program_name} generate [component-type] [options]
               |
-              |   #{opts.program_name} generate addon magical-key-bindings
+              |#{Term::ANSIColor.cyan('yap generate')} can be used to generate yap components, like an addon.
               |
+              |Generate commands:
+              |
+              |  #{Term::ANSIColor.yellow('addon')} - generates a yap addon skeleton
+              |
+              |Generate options:
             TEXT
-            exit @exit_status
+
+            opts.on('-h', '--help', 'Prints this help') do
+              puts opts
+              puts
+              puts  <<-TEXT.gsub(/^\s*\|/, '')
+                |Example: Generating an addon
+                |
+                |   #{opts.program_name} generate addon magical-key-bindings
+                |
+              TEXT
+              exit exit_status
+            end
           end
         end
       end

--- a/lib/yap/cli/options/generate.rb
+++ b/lib/yap/cli/options/generate.rb
@@ -28,11 +28,11 @@ module Yap
             opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
               |Usage: #{opts.program_name} generate [component-type] [options]
               |
-              |#{Term::ANSIColor.cyan('yap generate')} can be used to generate yap components, like an addon.
+              |#{Colors.cyan('yap generate')} can be used to generate yap components, like an addon.
               |
               |Generate commands:
               |
-              |  #{Term::ANSIColor.yellow('addon')} - generates a yap addon skeleton
+              |  #{Colors.yellow('addon')} - generates a yap addon skeleton
               |
               |Generate options:
             TEXT

--- a/lib/yap/cli/options/generate/addon.rb
+++ b/lib/yap/cli/options/generate/addon.rb
@@ -1,58 +1,57 @@
 module Yap
   module Cli
-    class Options::Generate::Addon < OptionsBase
-      attr_reader :command, :options
-
-      def initialize(options:)
-        @options = options
-        @exit_status = 0
-      end
-
-      def parse(args)
-        @addon_name = args.shift unless args.first =~ /^-/
-        unless @addon_name
-          args.unshift '--help'
-          STDERR.puts "Missing addon-name!"
-          @exit_status = 1
-          puts
-        end
-        option_parser.order!(args)
-      end
-
-      def command
-        @command ||= load_command('generate/addon').new(@addon_name)
-      end
-
-      def help_message
-        option_parser.to_s
-      end
-
-      private
-
-      def option_parser
-        OptionParser.new do |opts|
-          opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
-            |Usage: #{opts.program_name} generate addon [addon-name] [options]
-            |
-            |#{Term::ANSIColor.cyan('yap addon')} can be used to generate a yap addon skeleton provided an addon name.
-            |
-            |Generate addon options:
-          TEXT
-
-          opts.on('-h', '--help', 'Prints this help') do
-            puts opts
+    module Options
+      class Generate::Addon < Base
+        def parse(args)
+          @addon_name = args.shift unless args.first =~ /^-/
+          unless @addon_name
+            args.unshift '--help'
+            STDERR.puts "Missing addon-name!"
+            @exit_status = 1
             puts
-            puts  <<-TEXT.gsub(/^\s*\|/, '')
-              |Example: Generating an addon
-              |
-              |   #{opts.program_name} generate addon magical-key-bindings
-              |
-            TEXT
-            exit @exit_status
           end
+          option_parser.order!(args)
+        end
 
-          opts.on('--skip-git', 'Skip git initialization') do
-            command.use_git = false
+        def command
+          @command ||= load_command('generate/addon').new(@addon_name)
+        end
+
+        def exit_status
+          @exit_status || 0
+        end
+
+        def help_message
+          option_parser.to_s
+        end
+
+        private
+
+        def option_parser
+          OptionParser.new do |opts|
+            opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
+              |Usage: #{opts.program_name} generate addon [addon-name] [options]
+              |
+              |#{Term::ANSIColor.cyan('yap addon')} can be used to generate a yap addon skeleton provided an addon name.
+              |
+              |Generate addon options:
+            TEXT
+
+            opts.on('-h', '--help', 'Prints this help') do
+              puts opts
+              puts
+              puts  <<-TEXT.gsub(/^\s*\|/, '')
+                |Example: Generating an addon
+                |
+                |   #{opts.program_name} generate addon magical-key-bindings
+                |
+              TEXT
+              exit exit_status
+            end
+
+            opts.on('--skip-git', 'Skip git initialization') do
+              command.use_git = false
+            end
           end
         end
       end

--- a/lib/yap/cli/options/generate/addon.rb
+++ b/lib/yap/cli/options/generate/addon.rb
@@ -32,7 +32,7 @@ module Yap
             opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
               |Usage: #{opts.program_name} generate addon [addon-name] [options]
               |
-              |#{Term::ANSIColor.cyan('yap addon')} can be used to generate a yap addon skeleton provided an addon name.
+              |#{Colors.cyan('yap addon')} can be used to generate a yap addon skeleton provided an addon name.
               |
               |Generate addon options:
             TEXT

--- a/lib/yap/cli/options/generate/addon.rb
+++ b/lib/yap/cli/options/generate/addon.rb
@@ -6,7 +6,7 @@ module Yap
           @addon_name = args.shift unless args.first =~ /^-/
           unless @addon_name
             args.unshift '--help'
-            STDERR.puts "Missing addon-name!"
+            stderr.puts "Missing addon-name!"
             @exit_status = 1
             puts
           end

--- a/lib/yap/cli/options/generate/addon.rb
+++ b/lib/yap/cli/options/generate/addon.rb
@@ -1,8 +1,6 @@
 module Yap
   module Cli
-    class Options::Generate::Addon
-      include OptionsLoader
-
+    class Options::Generate::Addon < OptionsBase
       attr_reader :command, :options
 
       def initialize(options:)

--- a/lib/yap/cli/options/main.rb
+++ b/lib/yap/cli/options/main.rb
@@ -9,10 +9,6 @@ module Yap
           @options_dir = options_dir
         end
 
-        def [](key)
-          @options[key]
-        end
-
         def commands
           @commands.dup.freeze
         end

--- a/lib/yap/cli/options/main.rb
+++ b/lib/yap/cli/options/main.rb
@@ -70,7 +70,7 @@ module Yap
               puts opts
               commands = Dir[ File.dirname(__FILE__) + '/commands/*.rb' ].map do |path|
                 command = File.basename(path).sub(/\.rb$/, '')
-                "#{command}: #{Term::ANSIColor.cyan(opts.program_name + ' ' + command + ' --help')}"
+                "#{command}: #{Colors.cyan(opts.program_name + ' ' + command + ' --help')}"
               end
               commands = %|  #{commands.join("\n  ")}|
               puts <<-TEXT.gsub(/^\s*\|/, '')

--- a/lib/yap/cli/options/main.rb
+++ b/lib/yap/cli/options/main.rb
@@ -1,0 +1,118 @@
+module Yap
+  module Cli
+    module Options
+      class Main < Base
+        def initialize(config: Yap.configuration, options: {}, options_dir: 'yap/cli/options')
+          super(options: options)
+          @config = config
+          @commands = []
+          @options_dir = options_dir
+        end
+
+        def [](key)
+          @options[key]
+        end
+
+        def commands
+          @commands.dup.freeze
+        end
+
+        def parse(args)
+          option_parser.order!(args)
+          options_instance = self
+
+          @config.run_shell = false if args.any?
+
+          scope = ['..']
+          require_path = Pathname.new(@options_dir)
+          args_processed = []
+
+          while args.any?
+            if args_processed == args
+              puts "Unknown option(s): #{scope.concat([args.first]).join(' ')}"
+              exit 1
+            end
+            args_processed = args.dup
+
+            option_str = args.shift
+            current_scope = scope + [option_str]
+
+            begin
+              options_class = load_relative_constant current_scope.join('/')
+              options_instance = options_class.new(options: options)
+              options[:option] = options_instance
+              options_instance.parse(args)
+              @commands << options_instance.command
+
+              scope << option_str
+            rescue LoadError => ex
+              puts "Unknown option: #{option_str}"
+              puts
+              puts options_instance.help_message
+              exit 1
+            end
+          end
+        end
+
+        def help_message
+          option_parse.to_s
+        end
+
+        private
+
+        def option_parser
+          OptionParser.new do |opts|
+            opts.banner = <<-TEXT.gsub(/^\s*\|/, '')
+              |Usage: #{opts.program_name} [option|command]
+              |
+              |When a command is omitted the yap shell starts an interactive
+              |session. Otherwise, the command is executed.
+              |
+              |Shell options:
+            TEXT
+            opts.on('-h', '--help', 'Prints this help') do
+              puts opts
+              commands = Dir[ File.dirname(__FILE__) + '/commands/*.rb' ].map do |path|
+                command = File.basename(path).sub(/\.rb$/, '')
+                "#{command}: #{Term::ANSIColor.cyan(opts.program_name + ' ' + command + ' --help')}"
+              end
+              commands = %|  #{commands.join("\n  ")}|
+              puts <<-TEXT.gsub(/^\s*\|/, '')
+                |
+                |Commands:
+                |
+                |#{commands}
+                |
+              TEXT
+              exit 0
+            end
+
+            opts.on('--skip-first-time', 'Disables creating ~/.yap directory on shell startup') do
+              Yap.configuration.skip_first_time = true
+            end
+
+            opts.on('--addon-paths=PATHS', 'Paths to directories containing addons (comma-separated). This overwrites the default addon paths.') do |paths|
+              Yap.configuration.addon_paths = paths.split(',').map(&:strip)
+            end
+
+            opts.on('--no-addons', 'Disables auto-loading addons on shell startup') do
+              Yap.configuration.use_addons = false
+            end
+
+            opts.on('--no-history', 'Disables auto-loading or saving history') do
+              Yap.configuration.use_history = false
+            end
+
+            opts.on('--rcfiles=PATHS', 'Paths to Yap rcfiles in the order they should load (comma-separated). This overwrites the default rcfiles.') do |paths|
+              Yap.configuration.rcfiles = paths.split(',').map(&:strip)
+            end
+
+            opts.on('--no-rcfiles', 'Disables auto-loading rcfiles on shell startup') do
+              Yap.configuration.use_rcfiles = false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yap/cli/options/main.rb
+++ b/lib/yap/cli/options/main.rb
@@ -68,8 +68,8 @@ module Yap
             TEXT
             opts.on('-h', '--help', 'Prints this help') do
               puts opts
-              commands = Dir[ File.dirname(__FILE__) + '/commands/*.rb' ].map do |path|
-                command = File.basename(path).sub(/\.rb$/, '')
+              commands = Dir[ file_utils.dirname(__FILE__) + '/commands/*.rb' ].map do |path|
+                command = file_utils.basename(path).sub(/\.rb$/, '')
                 "#{command}: #{Colors.cyan(opts.program_name + ' ' + command + ' --help')}"
               end
               commands = %|  #{commands.join("\n  ")}|

--- a/lib/yap/shell/commands.rb
+++ b/lib/yap/shell/commands.rb
@@ -45,7 +45,7 @@ module Yap::Shell
 
   class BuiltinCommand < Command
     def self.===(other)
-      self.builtins.keys.include?(other.split(' ').first.to_sym) || super
+      self.builtins.keys.include?(other.split(' ').first.to_s.to_sym) || super
     end
 
     def self.builtins

--- a/lib/yap/support.rb
+++ b/lib/yap/support.rb
@@ -1,0 +1,6 @@
+require 'yap/support/file_loader'
+
+module Yap
+  module Support
+  end
+end

--- a/lib/yap/support/file_loader.rb
+++ b/lib/yap/support/file_loader.rb
@@ -1,0 +1,65 @@
+module Yap
+  module Support
+
+    # FileLoader is for loading constants from a given path. See
+    #
+    # Given a path, load all files/constants necessary to get the end
+    # result.
+    #
+    # For example, the following with try to load Yap::Cli::Options::Addon:
+    #
+    #     file_loader = FileLoader.new(
+    #       path: 'yap/cli/options/addon',
+    #       root: '/absolute/path/to/yap/lib'
+    #     )
+    #     file_loader.constant # => Yap::Cli::Options::Addon
+    #
+    # It will load each path part and try to expects to find a matching
+    # constant at each step.
+    #
+    class FileLoader
+      class ConstantNotFound < ::StandardError ; end
+
+      def self.load_constant_from_path(path)
+        new(path: path, root: Yap.root).constant
+      end
+
+      attr_reader :path, :root
+
+      def initialize(path: , root:)
+        @path = path
+        @root = root
+      end
+
+      def constant
+        requiring_parts = []
+
+        # Start at Object, then iterate over the path_parts building up
+        # the files/constants to load at each step.
+        constant = path_parts.reduce(Object) do |constant, path_part|
+          requiring_parts << path_part
+          file = root.join('lib', requiring_parts.join('/') + '.rb')
+          constant_name = path_part.capitalize
+
+          if File.exists?(file)
+            require file
+          end
+
+          if constant.const_defined?(constant_name)
+            constant.const_get(constant_name)
+          else
+            fail ConstantNotFound, "Expected to find #{constant_name}, but did not. Is it defined?"
+          end
+        end
+        Treefell['shell'].puts "#{inspect} loaded: #{constant}"
+        constant
+      end
+
+      private
+
+      def path_parts
+        path.to_s.split('/')
+      end
+    end
+  end
+end

--- a/lib/yap/support/file_loader.rb
+++ b/lib/yap/support/file_loader.rb
@@ -48,7 +48,7 @@ module Yap
           if constant.const_defined?(constant_name)
             constant.const_get(constant_name)
           else
-            fail ConstantNotFound, "Expected to find #{constant_name}, but did not. Is it defined?"
+            fail ConstantNotFound, "Expected to find #{constant_name} in #{path}, but did not. Is it defined?"
           end
         end
         Treefell['shell'].puts "#{inspect} loaded: #{constant}"

--- a/lib/yap/support/file_utils.rb
+++ b/lib/yap/support/file_utils.rb
@@ -1,0 +1,31 @@
+require 'fileutils'
+
+module Yap
+  module Support
+    class FileUtils
+      def basename(*args)
+        ::File.basename(*args)
+      end
+
+      def dirname(*args)
+        ::File.dirname(*args)
+      end
+
+      def join(*paths)
+        ::File.join(*paths)
+      end
+
+      def mkdir_p(*args)
+        ::FileUtils.mkdir_p(*args)
+      end
+
+      def read(*args)
+        ::File.read(*args)
+      end
+
+      def write(*args)
+        ::File.write(*args)
+      end
+    end
+  end
+end

--- a/lib/yap/support/file_utils_helper.rb
+++ b/lib/yap/support/file_utils_helper.rb
@@ -1,0 +1,16 @@
+require 'yap/support/file_utils'
+require 'yap/support/file_loader'
+
+module Yap
+  module Support
+    module FileUtilsHelper
+      def file_utils
+        FileUtils.new
+      end
+
+      def file_loader
+        FileLoader
+      end
+    end
+  end
+end

--- a/rcfiles/yaprc
+++ b/rcfiles/yaprc
@@ -237,6 +237,9 @@ world.editor.bind(:ctrl_r) do
   world.addons[:'history-search'].prompt_user_to_search
 end
 
+world.editor.bind(:up_arrow) { world.addons[:'history'].back }
+world.editor.bind(:down_arrow) { world.addons[:'history'].forward }
+
 # Or, you can set the trigger key for a particular set of macros
 # by specifying it when you call .configure(...).
 world.addons[:'keyboard-macros'].configure(trigger_key: ?\C-g) do |macro|

--- a/spec/features/addons/generating_an_addon_spec.rb
+++ b/spec/features/addons/generating_an_addon_spec.rb
@@ -1,22 +1,8 @@
 require 'spec_helper'
 
 describe 'Generating an addon', type: :feature, repl: false do
-  let(:addons_path) { tmp_dir.join('addons/') }
-  let(:yaprc_path) { tmp_dir.join('yaprc') }
-  let(:yaprc_contents) { '' }
-
-  let(:yap_cli_args) do
-    [
-      'generate', 'addon', 'foo-bar'
-    ]
-  end
-
   before do
-    set_yap_command_line_arguments yap_cli_args
-
-    turn_on_debug_log(debug: 'editor')
-
-    reinitialize_shell
+    yap 'generate addon foo-bar'
   end
 
   it 'generates an addon in the current working directory' do

--- a/spec/features/addons/generating_an_addon_spec.rb
+++ b/spec/features/addons/generating_an_addon_spec.rb
@@ -7,7 +7,7 @@ describe 'Generating an addon', type: :feature, repl: false do
 
   it 'generates an addon in the current working directory' do
     # foo-addon is a shell function added by the foo-addon defined above;
-    expect { output }.to have_printed_lines <<-TEXT.gsub(/^\s*\|/, '')
+    expect { output }.to have_printed_lines <<-TEXT.strip_heredoc
       |Creating addon foo-bar in yap-shell-addon-foo-bar/
       |
       |Create directory: yap-shell-addon-foo-bar done

--- a/spec/features/addons/generating_an_addon_spec.rb
+++ b/spec/features/addons/generating_an_addon_spec.rb
@@ -50,6 +50,6 @@ describe 'Generating an addon', type: :feature, repl: false do
       |Now, to get started:
       |
       |   cd yap-shell-addon-foo-bar
-      TEXT
+    TEXT
   end
 end

--- a/spec/features/addons/listing_addons_spec.rb
+++ b/spec/features/addons/listing_addons_spec.rb
@@ -1,19 +1,8 @@
 require 'spec_helper'
 
 describe 'Listing addons', type: :feature, repl: false do
-  let(:addons_path) { tmp_dir.join('addons/') }
-  let(:yaprc_path) { tmp_dir.join('yaprc') }
-  let(:yaprc_contents) { '' }
-
-  let(:yap_cli_args) do
-    [
-      'addon', 'list'
-    ]
-  end
-
   before do
-    set_yap_command_line_arguments yap_cli_args
-    reinitialize_shell
+    yap 'generate addon list'
   end
 
   it 'listing addons completes successfully' do

--- a/spec/features/addons/listing_addons_spec.rb
+++ b/spec/features/addons/listing_addons_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'Listing addons', type: :feature, repl: false do
+  let(:addons_path) { tmp_dir.join('addons/') }
+  let(:yaprc_path) { tmp_dir.join('yaprc') }
+  let(:yaprc_contents) { '' }
+
+  let(:yap_cli_args) do
+    [
+      'addon', 'list'
+    ]
+  end
+
+  before do
+    set_yap_command_line_arguments yap_cli_args
+    reinitialize_shell
+  end
+
+  it 'listing addons completes successfully' do
+    expect { shell }.to have_exit_code(0)
+  end
+end

--- a/spec/features/addons/listing_addons_spec.rb
+++ b/spec/features/addons/listing_addons_spec.rb
@@ -27,10 +27,10 @@ describe 'Listing addons', type: :feature, repl: false do
   it 'lists addons, and exits successfully' do
     yap "addon list"
 
-    expect { output }.to have_printed_lines <<-TEXT.strip_heredoc.chomp
-      |bar (enabled)
-      |foo (enabled)
-    TEXT
+    expect { output }.to have_printed_lines [
+      "bar  enabled  (0.1.0)  \n",
+      "foo  enabled  (0.1.0)  "
+    ]
     expect { shell }.to have_exit_code(0)
   end
 

--- a/spec/features/addons/listing_addons_spec.rb
+++ b/spec/features/addons/listing_addons_spec.rb
@@ -25,7 +25,7 @@ describe 'Listing addons', type: :feature, repl: false do
   end
 
   it 'lists addons, and exits successfully' do
-    yap "--addon-paths #{addons_path.to_s} addon list"
+    yap "addon list"
 
     expect { output }.to have_printed_lines <<-TEXT.strip_heredoc.chomp
       |bar (enabled)
@@ -35,19 +35,19 @@ describe 'Listing addons', type: :feature, repl: false do
   end
 
   it 'can list disabled addons only' do
-    yap "--addon-paths #{addons_path.to_s} addon disable foo"
+    yap "addon disable foo"
     expect { output }.to have_printed_line 'Addon foo has been disabled'
 
-    yap "--addon-paths #{addons_path.to_s} addon list --disabled"
+    yap "addon list --disabled"
     expect { output }.to have_printed_line 'foo'
     expect { output }.to_not have_printed_line 'bar'
   end
 
   it 'can list enabled addons only' do
-    yap "--addon-paths #{addons_path.to_s} addon disable foo"
+    yap "addon disable foo"
     expect { output }.to have_printed_line 'Addon foo has been disabled'
 
-    yap "--addon-paths #{addons_path.to_s} addon list --enabled"
+    yap "addon list --enabled"
     expect { output }.to have_printed_line 'bar'
     expect { output }.to_not have_printed_line 'foo'
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,25 +39,23 @@ RSpec.configure do |config|
     mkdir tmp_dir
     Dir.chdir tmp_dir
 
-    set_yap_command_line_arguments \
-      '--no-history', '--no-addons', '--no-rcfiles', '--skip-first-time'
-
-    turn_on_debug_log(debug: 'editor')
-    initialize_shell
-
     if self.class.metadata[:repl] == false
-      # no-op if the test specificaly says it doesn't use a repl
+      # no-op if the test specifically says it doesn't use a repl
       # This is likely when we're expecting yap to print information
       # and exit immediately
     else
+      set_yap_command_line_arguments \
+        '--no-history', '--no-addons', '--no-rcfiles', '--skip-first-time'
+
+      initialize_shell
       type "cd #{tmp_dir}"
       enter
 
       type "pwd"
       enter
       expect { output }.to have_printed(File.expand_path(tmp_dir))
+      clear_all_output
     end
-    clear_all_output
   end
 
   config.after(:all, type: :feature) do

--- a/spec/support/factories/yap_addon_factory.rb
+++ b/spec/support/factories/yap_addon_factory.rb
@@ -1,0 +1,55 @@
+require 'pathname'
+
+class YapAddonFactory
+  def self.create(**kwargs)
+    new(**kwargs).create
+  end
+
+  attr_reader :dir, :contents, :name, :version
+
+  def initialize(dir:, contents: {}, name:, version: '0.1.0')
+    @dir = Pathname.new dir
+    @contents = contents
+    @contents[:initialize_world] ||= "# no-op"
+    @name = name
+    @version = version
+  end
+
+  def create
+    FileUtils.mkdir_p lib_path.to_s
+    File.write addon_rb_path, <<-RUBY.strip_heredoc
+      |module #{full_name.split(/\W+/).map(&:capitalize).join}
+      |  class Addon < ::Yap::Addon::Base
+      |    self.export_as :'#{name}'
+      |
+      |    def initialize_world(world)
+      |      #{contents[:initialize_world]}
+      |    end
+      |  end
+      |end
+    RUBY
+  end
+
+  private
+
+  def addon_path
+    @dir.join full_name_with_version
+  end
+
+  def full_name
+    "yap-shell-addon-#{@name}"
+  end
+
+  def full_name_with_version
+    "#{full_name}-#{@version}"
+  end
+
+  def lib_path
+    addon_path.join 'lib'
+  end
+
+  def addon_rb_path
+    lib_path.join "#{full_name}.rb"
+  end
+
+end

--- a/spec/support/matchers/have_exit_code.rb
+++ b/spec/support/matchers/have_exit_code.rb
@@ -1,0 +1,22 @@
+RSpec::Matchers.define :have_exit_code do |expected|
+  shell = nil
+
+  match do |block|
+    shell = block.call
+    Timeout.timeout(60) do
+      loop do
+        break if shell.exited?
+        sleep 0.01
+      end
+      expect(shell.exit_code).to eq expected
+    end
+  end
+
+  failure_message do |actual|
+    "expected that the last command would have exit code of #{expected}, but it had #{shell.exit_code.inspect}"
+  end
+
+  def supports_block_expectations?
+    true
+  end
+end

--- a/spec/support/matchers/have_printed.rb
+++ b/spec/support/matchers/have_printed.rb
@@ -36,7 +36,8 @@ RSpec::Matchers.define :have_printed_lines do |expected|
 
   match do |block|
     begin
-      expected.lines.each do |line|
+      expected_lines = expected.is_a?(String) ? expected.lines : expected # assume array
+      expected_lines.each do |line|
         current_line = line
         regex = /#{Regexp.escape(line)}/m
         very_soon do

--- a/spec/support/yap_spec_dsl.rb
+++ b/spec/support/yap_spec_dsl.rb
@@ -43,6 +43,14 @@ module Yap
         @stderr = stderr
       end
 
+      def exit_code
+        @childprocess.exit_code
+      end
+
+      def exited?
+        @childprocess.exited?
+      end
+
       def io
         @childprocess.io if @childprocess
       end
@@ -175,7 +183,7 @@ module Yap
 
       def reinitialize_shell
         initialize_shell
-        clear_all_output(console: false)        
+        clear_all_output(console: false)
       end
 
       def shell

--- a/spec/support/yap_spec_dsl.rb
+++ b/spec/support/yap_spec_dsl.rb
@@ -1,7 +1,8 @@
 require 'fileutils'
 require 'pathname'
-require 'timeout'
 require 'ostruct'
+require 'shellwords'
+require 'timeout'
 
 module Yap
   module Spec
@@ -155,6 +156,18 @@ module Yap
         yap_dir.join('tmp/specroot').expand_path
       end
 
+      def yap_command
+        @yap_command ||= 'yap-dev'
+      end
+
+      def set_yap_command(command)
+        @yap_command = command
+      end
+
+      def yap_command_path
+        yap_dir.join('bin', yap_command).to_s
+      end
+
       def yap_dir
         Pathname.new File.dirname(__FILE__) + '/../../'
       end
@@ -174,7 +187,7 @@ module Yap
 
       def initialize_shell
         Shell.new(
-          dir: yap_dir.join('bin/yap-dev').to_s,
+          dir: yap_command_path,
           args: yap_command_line_arguments,
           stdout: stdout,
           stderr: stderr
@@ -184,6 +197,12 @@ module Yap
       def reinitialize_shell
         initialize_shell
         clear_all_output(console: false)
+      end
+
+      def yap(argstring)
+        args = argstring.shellsplit
+        set_yap_command_line_arguments args
+        reinitialize_shell
       end
 
       def shell

--- a/spec/support/yap_spec_dsl.rb
+++ b/spec/support/yap_spec_dsl.rb
@@ -156,6 +156,10 @@ module Yap
         yap_dir.join('tmp/specroot').expand_path
       end
 
+      def addons_path
+        tmp_dir.join('addons/')
+      end
+
       def yap_command
         @yap_command ||= 'yap-dev'
       end
@@ -200,6 +204,7 @@ module Yap
       end
 
       def yap(argstring)
+        clear_all_output console: false
         args = argstring.shellsplit
         set_yap_command_line_arguments args
         reinitialize_shell
@@ -229,6 +234,7 @@ module Yap
       end
 
       def clear_all_output(console: true)
+        return unless shell
         if console
           type 'echo done'
           enter

--- a/spec/support/yap_spec_dsl.rb
+++ b/spec/support/yap_spec_dsl.rb
@@ -204,8 +204,9 @@ module Yap
       end
 
       def yap(argstring)
+        defaults = "--addon-paths #{addons_path.to_s} "
         clear_all_output console: false
-        args = argstring.shellsplit
+        args = (defaults + argstring).shellsplit
         set_yap_command_line_arguments args
         reinitialize_shell
       end


### PR DESCRIPTION
- Bring back bin/yap for testing
- Update up/down arrow key bindings to use the history addon back/forward since it will match text up to the cursor position.
- #to_s before #to_sym, in cases there's nothing to split.
- Cheating yap instead of yap-shell-core. Need to fix this.
- Refactoring: Extract out load_constant_from_path implementation into Yap::Support::FileLoader.
- Refactoring: Eliminate OptionsLoader module and use an OptionsBase base-class.
- Refactoring: Move Options to Options::Main, add Options::Base to be subclass for all options.
- Refactoring: remove unused method #[] on yap/cli/options/main
- Refactoring: Making Colors available inside of Yap::Cli namespace.
- Refactoring: introducing local stdout and stderr for CLI options.
- Refactoring: Pushing out file dependencies into Yap::Support::FileUtils
- bundle update Gemfile.travis
- Adding super-basic listing addons feature spec.
- #strip_heredoc is only available in tests currently
- Providing an alternate way of executing yap commands in specs.
- Provide stdout, stderr protected methods for Yap::Cli::Options.
- Fleshing out the listing addon spec.
- Spec update: pushing default args into the yap helper method so they don't muddy up the intent of the examples they're used in.
- Yap cli has learned "addon install" and "addon uninstall"
- Updating "yap addon list" command to show versions of addons installed.
